### PR TITLE
logrotate: do not move binary logrotate to /usr/bin

### DIFF
--- a/meta/recipes-core/udev/udev-extraconf/mount.sh
+++ b/meta/recipes-core/udev/udev-extraconf/mount.sh
@@ -8,7 +8,7 @@
 MOUNT="/bin/mount"
 PMOUNT="/usr/bin/pmount"
 UMOUNT="/bin/umount"
-for line in `grep -v ^# /etc/udev/mount.blacklist /etc/udev/mount.blacklist.d/*`
+for line in `grep -h -v ^# /etc/udev/mount.blacklist /etc/udev/mount.blacklist.d/*`
 do
 	if [ ` expr match "$DEVNAME" "$line" ` -gt 0 ];
 	then

--- a/meta/recipes-core/udev/udev-extraconf/mount.sh
+++ b/meta/recipes-core/udev/udev-extraconf/mount.sh
@@ -8,7 +8,7 @@
 MOUNT="/bin/mount"
 PMOUNT="/usr/bin/pmount"
 UMOUNT="/bin/umount"
-for line in `grep -v ^# /etc/udev/mount.blacklist`
+for line in `grep -v ^# /etc/udev/mount.blacklist /etc/udev/mount.blacklist.d/*`
 do
 	if [ ` expr match "$DEVNAME" "$line" ` -gt 0 ];
 	then

--- a/meta/recipes-core/udev/udev-extraconf_1.1.bb
+++ b/meta/recipes-core/udev/udev-extraconf_1.1.bb
@@ -23,6 +23,7 @@ do_install() {
     install -m 0644 ${WORKDIR}/autonet.rules       ${D}${sysconfdir}/udev/rules.d/autonet.rules
     install -m 0644 ${WORKDIR}/localextra.rules    ${D}${sysconfdir}/udev/rules.d/localextra.rules
 
+    install -d ${D}${sysconfdir}/udev/mount.blacklist.d
     install -m 0644 ${WORKDIR}/mount.blacklist     ${D}${sysconfdir}/udev/
 
     install -d ${D}${sysconfdir}/udev/scripts/

--- a/meta/recipes-extended/logrotate/logrotate_3.9.1.bb
+++ b/meta/recipes-extended/logrotate/logrotate_3.9.1.bb
@@ -53,7 +53,7 @@ do_compile_prepend() {
 }
 
 do_install(){
-    oe_runmake install DESTDIR=${D} PREFIX=${D} MANDIR=${mandir} BINDIR=${bindir}
+    oe_runmake install DESTDIR=${D} PREFIX=${D} MANDIR=${mandir}
     mkdir -p ${D}${sysconfdir}/logrotate.d
     mkdir -p ${D}${sysconfdir}/cron.daily
     mkdir -p ${D}${localstatedir}/lib


### PR DESCRIPTION
In oe-core commit a46d3646a3e1781be4423b508ea63996b3cfca8a
...
Author: Fahad Usman fahad_usman@mentor.com
Date:   Tue Aug 26 13:16:48 2014 +0500

```
logrotate: obey our flags

Needed to quiet GNU_HASH warnings, and some minor fixes.
```

...
it explicitly move logrotate to /usr/bin without any reason,
which is against the original Linux location /usr/sbin.

So partly revert the above commit which let logrotate be
kept in the original place /usr/sbin.

(From OE-Core rev: 0007436b486fd0bea9e6ef60bf57603e7cfce54b)

Signed-off-by: Hongxu Jia hongxu.jia@windriver.com
Signed-off-by: Ross Burton ross.burton@intel.com
Signed-off-by: Richard Purdie richard.purdie@linuxfoundation.org
