### PR TITLE
linux-firmware: package firmware for Marvell 88W8688

### DIFF
--- a/meta/recipes-kernel/linux-firmware/linux-firmware_git.bb
+++ b/meta/recipes-kernel/linux-firmware/linux-firmware_git.bb
@@ -164,7 +164,7 @@ do_install() {
 
 PACKAGES =+ "${PN}-ralink-license ${PN}-ralink \
              ${PN}-radeon-license ${PN}-radeon \
-             ${PN}-marvell-license ${PN}-sd8686 ${PN}-sd8787 ${PN}-sd8797 \
+             ${PN}-marvell-license ${PN}-sd8686 ${PN}-sd8688 ${PN}-sd8787 ${PN}-sd8797 \
              ${PN}-ti-connectivity-license ${PN}-wl12xx ${PN}-wl18xx \
              ${PN}-vt6656-license ${PN}-vt6656 \
              ${PN}-rtl-license ${PN}-rtl8192cu ${PN}-rtl8192ce ${PN}-rtl8192su \
@@ -232,6 +232,7 @@ RDEPENDS_${PN}-radeon += "${PN}-radeon-license"
 
 # For marvell
 LICENSE_${PN}-sd8686 = "Firmware-Marvell"
+LICENSE_${PN}-sd8688 = "Firmware-Marvell"
 LICENSE_${PN}-sd8787 = "Firmware-Marvell"
 LICENSE_${PN}-sd8797 = "Firmware-Marvell"
 
@@ -239,6 +240,10 @@ FILES_${PN}-marvell-license = "/lib/firmware/LICENCE.Marvell"
 FILES_${PN}-sd8686 = " \
   /lib/firmware/libertas/sd8686_v9* \
   /lib/firmware/sd8686* \
+"
+FILES_${PN}-sd8688 = " \
+  /lib/firmware/libertas/sd8688* \
+  /lib/firmware/mrvl/sd8688* \
 "
 FILES_${PN}-sd8787 = " \
   /lib/firmware/mrvl/sd8787_uapsta.bin \
@@ -248,6 +253,7 @@ FILES_${PN}-sd8797 = " \
 "
 
 RDEPENDS_${PN}-sd8686 += "${PN}-marvell-license"
+RDEPENDS_${PN}-sd8688 += "${PN}-marvell-license"
 RDEPENDS_${PN}-sd8787 += "${PN}-marvell-license"
 RDEPENDS_${PN}-sd8797 += "${PN}-marvell-license"
 


### PR DESCRIPTION
According to error messages from guruplug

[   35.826441] btmrvl_sdio mmc0:0001:2: Direct firmware load for mrvl/sd8688_helper.bin failed with error -2
[   35.903291] Bluetooth: request_firmware(helper) failed, error code = -2
[   35.909942] Bluetooth: Failed to download helper!
[   36.052820] Bluetooth: Downloading firmware failed!
...
[  764.422739] libertas_sdio: Libertas SDIO driver
[  764.438213] libertas_sdio: Copyright Pierre Ossman
root@homepilot:~# [  764.461186] libertas_sdio mmc0:0001:1: Direct firmware load for libertas/sd8688_helper.bin failed with error -2
[  764.488234] libertas_sdio mmc0:0001:1: Direct firmware load for sd8688_helper.bin failed with error -2
[  764.507382] libertas_sdio: failed to find firmware (-2)

and http://wiki.beyondlogic.org/index.php?title=GuruPlug_Libertas_SD8688,
package the firmware files for Marvell 88W8688, too.

Signed-off-by: Jens Rehsack sno@netbsd.org
